### PR TITLE
Fix "not found" error on fresh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,8 +119,6 @@ print_logo
 probe_arch
 probe_os
 
-detect_profile
-
 URL_PREFIX="https://github.com/chiselstrike/homebrew-tap/releases/latest/download/"
 
 TARGET="${OS}_$ARCH"

--- a/install.sh
+++ b/install.sh
@@ -73,16 +73,14 @@ detect_profile() {
   local SHELLTYPE
   SHELLTYPE="$(basename "/$SHELL")"
 
-  if [ "$SHELLTYPE" = "bash" ]; then
+  if [ -n "$BASH" ]; then
     if [ -f "$HOME/.bashrc" ]; then
       DETECTED_PROFILE="$HOME/.bashrc"
     elif [ -f "$HOME/.bash_profile" ]; then
       DETECTED_PROFILE="$HOME/.bash_profile"
     fi
-  elif [ "$SHELLTYPE" = "zsh" ]; then
+  elif [ -n "$ZSH_NAME" ]; then
     DETECTED_PROFILE="$HOME/.zshrc"
-  elif [ "$SHELLTYPE" = "fish" ]; then
-    DETECTED_PROFILE="$HOME/.config/fish/conf.d/turso.fish"
   fi
 
   if [ -z "$DETECTED_PROFILE" ]; then
@@ -121,6 +119,8 @@ print_logo
 probe_arch
 probe_os
 
+detect_profile
+
 URL_PREFIX="https://github.com/chiselstrike/homebrew-tap/releases/latest/download/"
 
 TARGET="${OS}_$ARCH"
@@ -149,4 +149,4 @@ printf "\nTurso CLI installed!\n\n"
 printf "If you are a new user, you can sign up with ${bright_blue}turso auth signup${reset}.\n\n"
 printf "If you already have an account, please login with ${bright_blue}turso auth login${reset}.\n\n"
 
-turso auth signup
+$INSTALL_DIRECTORY/turso auth signup


### PR DESCRIPTION
The login command at the end of the script was running without the CLI being in `$PATH`.

I also fixed the shell detection for Zsh (`$SHELL` is not always reliable).

I could not get the script to work in `fish`.