### PR TITLE
Fix installations for ARM machines

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -12,11 +12,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-14]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: OS and arch
+        run: |
+          echo "Runner label: ${{ matrix.os }}"
+          echo "OS: $(uname -s) Arch: $(uname -m)"
 
       - name: Run Install Script
         run: |

--- a/install.sh
+++ b/install.sh
@@ -141,6 +141,7 @@ install_libsql_server() {
     case $ARCH in
         x86_64) ARCH_TARGET="x86_64" ;;
         aarch64) ARCH_TARGET="aarch64" ;;
+        arm64) ARCH_TARGET="aarch64" ;;
         *)
             printf "Architecture ${ARCH} is not supported for libsql-server\n"
             return 1


### PR DESCRIPTION
In the libsql-server installations, we had missed `arm64` arch targets. I have also updated our workflow for this to test installations for this arch.

closes #12 