### PR TITLE
Find correct path to .zshrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,7 +81,7 @@ detect_profile() {
       DETECTED_PROFILE="$HOME/.bash_profile"
     fi
   elif [ "$SHELLTYPE" = "zsh" ]; then
-    DETECTED_PROFILE="$HOME/.zshrc"
+    DETECTED_PROFILE="${ZDOTDIR:-$HOME}/.zshrc"
   elif [ "$SHELLTYPE" = "fish" ]; then
     DETECTED_PROFILE="$HOME/.config/fish/conf.d/turso.fish"
   fi
@@ -93,8 +93,8 @@ detect_profile() {
       DETECTED_PROFILE="$HOME/.bashrc"
     elif [ -f "$HOME/.bash_profile" ]; then
       DETECTED_PROFILE="$HOME/.bash_profile"
-    elif [ -f "$HOME/.zshrc" ]; then
-      DETECTED_PROFILE="$HOME/.zshrc"
+    elif [ -f "${ZDOTDIR:-$HOME}/.zshrc" ]; then
+      DETECTED_PROFILE="${ZDOTDIR:-$HOME}/.zshrc"
     elif [ -d "$HOME/.config/fish" ]; then
       DETECTED_PROFILE="$HOME/.config/fish/conf.d/turso.fish"
     fi


### PR DESCRIPTION
Zsh provides a way to keep all related files in a separate directory by exporting a ZDOTDIR variable, but the install script doesn't check It.

This is a minor issue, but may lead to some bad first time experience for some users, since the required lines would be added in a .zshrc file that is never sourced.