### PR TITLE
Move install directory to end of PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ update_profile() {
    if [[ -n "$PROFILE_FILE" ]]; then
      if ! grep -q "\.turso" $PROFILE_FILE; then
         printf "\n${bright_blue}Updating profile ${reset}$PROFILE_FILE\n"
-        printf "\n# Turso\nexport PATH=\"$INSTALL_DIRECTORY:\$PATH\"\n" >> $PROFILE_FILE
+        printf "\n# Turso\nexport PATH=\"\$PATH:$INSTALL_DIRECTORY\"\n" >> $PROFILE_FILE
         printf "\nTurso will be available when you open a new terminal.\n"
         printf "If you want to make Turso available in this terminal, please run:\n"
         printf "\nsource $PROFILE_FILE\n"


### PR DESCRIPTION
For some dev environments, both turso and sqld may be installed/managed by another package manager (like Nix). In these cases, having ~/.turso at the front of the PATH will cause certain commands to fail. For instance, since the Turso install script also automatically installs sqld in ~/.turso, running `turso dev` will attempt to use ~/.turso/sqld instead of the sqld that is installed via the package manager. In environments like NixOS, this will completely break `turso dev` because the automatically installed sqld binary cannot run on NixOS, and since it exists earlier in the PATH it supercedes the properly installed sqld Nix package.

This patch tweaks the PATH modification so that the ~/.turso folder is placed at the end of the existing PATH, preventing it from overriding any other installed/managed versions of turso or sqld.